### PR TITLE
Add blur behind hero text

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -19,10 +19,10 @@ const HeroSection = () => {
       <div className="container mx-auto px-4 z-10 flex flex-col items-center text-center">
         {/* Added background, padding, rounding and blur to this inner div */}
         <div
-          className="max-w-4xl bg-black/20 backdrop-blur-[2px] py-8 px-6" // Removed rounded-lg
+          className="max-w-4xl backdrop-blur-[2px] py-8 px-6"
           style={{
-            maskImage: 'radial-gradient(ellipse at center, black 40%, transparent 90%)', // Smoother fade: starts earlier, wider transition
-            WebkitMaskImage: 'radial-gradient(ellipse at center, black 40%, transparent 90%)' // For Safari compatibility
+            maskImage: 'radial-gradient(ellipse at center, black 20%, transparent 40%)', // Quick fade to keep blur tight
+            WebkitMaskImage: 'radial-gradient(ellipse at center, black 20%, transparent 40%)'
           }}
         >
           <motion.h1 


### PR DESCRIPTION
## Summary
- make the hero text container only blur the background, with no tint
- fade the blur out more rapidly

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*